### PR TITLE
Improve consistency of line breaks between editor and viewer

### DIFF
--- a/src/components/viewer.js
+++ b/src/components/viewer.js
@@ -20,26 +20,14 @@ const renderChildren = (nodes, isListItem) =>
     }
     // Text node
     if (typeof node === 'string') {
-      const line = node.replace(/\n/g, "");
-
-      if (line.length) {
-        return <span style={{width: "100%", display: "block"}}>{line}</span>;
-      }
-
-      const emptyLineStyles = {
-        width: "100%",
-        margin: 0,
-        display: "block",
-        minHeight: "1em",
-        padding: 0,
-        position: "relative",
-      };
-
-      return (<span style={emptyLineStyles}>&nbsp;</span>);
+      return node.replace(/\n$/, "").split("\n").map((line, k) => (
+        <span style={{width: "100%", display: "block"}}>
+          {line.trim() === "" ? "\u200B" : line}
+        </span>
+      ));
     }
 
     // defaultText handling
-
     if (node.type === 'Text' && !node.children) {
       return node.defaultText;
     }


### PR DESCRIPTION
## In editor:
## ![image](https://cloud.githubusercontent.com/assets/848347/17819988/654f2e20-65ff-11e6-853f-2f27282296b6.png)
## In viewer:
## ![image](https://cloud.githubusercontent.com/assets/848347/17820006/7ed80aba-65ff-11e6-981e-a9c6656d7ee0.png)
## After this PR:

![image](https://cloud.githubusercontent.com/assets/848347/17820012/84490af8-65ff-11e6-853d-d3086dc79d0b.png)
