### PR TITLE
Don't trim whitespace when determining to create line filler

### DIFF
--- a/src/components/viewer.js
+++ b/src/components/viewer.js
@@ -26,7 +26,7 @@ const renderChildren = (nodes, paragraphStyles, isListItem) =>
     if (typeof node === 'string') {
       return node.replace(/\n$/, "").split("\n").map((line, k) => (
         <span style={{width: "100%", display: "block"}}>
-          {line.trim() === "" ? "\u200B" : line}
+          {line.length === 0 ? "\u200B" : line}
         </span>
       ));
     }


### PR DESCRIPTION
If you created a line with a bunch of spaces and then underlined it for a horizontal rule effect, it wouldn't appear due to the `.trim()` here. Fixed. 
