### PR TITLE
Whitelist data:image/* protocols

### DIFF
--- a/src/components/viewer.js
+++ b/src/components/viewer.js
@@ -28,10 +28,11 @@ const escapeHtml = (str) => {
   return div.innerHTML;
 }
 
-const whitelistedProtocols = ['http', 'https', 'mailto'];
+const whitelistedProtocols = ['http://', 'https://', 'mailto://', 'data:image/gif',
+  'data:image/png', 'data:image/jpeg', 'data:image/webp'];
 
 const isDangerousUrl = (url) => {
-  return !whitelistedProtocols.some(proto => url.startsWith(proto + '://'));
+  return !whitelistedProtocols.some(proto => url.startsWith(proto));
 };
 
 // Prepend an http:// in front of any markdown links that don't begin with a valid protocol such as
@@ -40,7 +41,7 @@ const isDangerousUrl = (url) => {
 const sanitizeMarkdown = (markdown) => {
   return markdown.replace(/\(([a-z]+):/ig, (match, proto) => {
     if (!whitelistedProtocols.includes(proto)) {
-      return match.replace(proto + ':', 'http://');
+      return match.replace(proto, 'http://');
     }
     return match;
   });


### PR DESCRIPTION
This whitelists `data:image` URI protocols while still not allowing for `data:text/html` or other unsafe protocols.

Fixes issue reported by Plotly (images not loading in presentations due to disallowed base64 encoded images via data URIs).

The build doesn't pass lint; there will be another PR to fix that.